### PR TITLE
Upgrade to v0.2.0 (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Shipped version:** 0.1.0~ynh1
+**Shipped version:** 0.2.0~ynh1
 ## Documentation and resources
 
 - Upstream app code repository: <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_es.md
+++ b/README_es.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Versión actual:** 0.1.0~ynh1
+**Versión actual:** 0.2.0~ynh1
 ## Documentaciones y recursos
 
 - Repositorio del código fuente oficial de la aplicación : <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_eu.md
+++ b/README_eu.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Paketatutako bertsioa:** 0.1.0~ynh1
+**Paketatutako bertsioa:** 0.2.0~ynh1
 ## Dokumentazioa eta baliabideak
 
 - Jatorrizko aplikazioaren kode-gordailua: <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Version incluse :** 0.1.0~ynh1
+**Version incluse :** 0.2.0~ynh1
 ## Documentations et ressources
 
 - Dépôt de code officiel de l’app : <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_gl.md
+++ b/README_gl.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Versión proporcionada:** 0.1.0~ynh1
+**Versión proporcionada:** 0.2.0~ynh1
 ## Documentación e recursos
 
 - Repositorio de orixe do código: <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_id.md
+++ b/README_id.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Versi terkirim:** 0.1.0~ynh1
+**Versi terkirim:** 0.2.0~ynh1
 ## Dokumentasi dan sumber daya
 
 - Depot kode aplikasi hulu: <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_nl.md
+++ b/README_nl.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Geleverde versie:** 0.1.0~ynh1
+**Geleverde versie:** 0.2.0~ynh1
 ## Documentatie en bronnen
 
 - Upstream app codedepot: <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_ru.md
+++ b/README_ru.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**Поставляемая версия:** 0.1.0~ynh1
+**Поставляемая версия:** 0.2.0~ynh1
 ## Документация и ресурсы
 
 - Репозиторий кода главной ветки приложения: <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -20,7 +20,7 @@ A [nostr](https://github.com/nostr-protocol/nostr) relay with a invite hierarchy
 
 
 
-**分发版本：** 0.1.0~ynh1
+**分发版本：** 0.2.0~ynh1
 ## 文档与资源
 
 - 上游应用代码库： <https://github.com/github-tijlxyz/khatru-pyramid>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Khatru Pyramid"
 description.en = "Nostr invite relay"
 description.fr = "Nostr relais d'invitation"
 
-version = "0.1.0~ynh1"
+version = "0.2.0~ynh1"
 
 maintainers = ["tijlxyz"]
 
@@ -47,8 +47,8 @@ ram.runtime = "50M"
     [resources.sources.main]
     extract = false
     rename = "khatru-pyramid"
-    amd64.url = "https://github.com/github-tijlxyz/khatru-pyramid/releases/download/v0.1.0/khatru-pyramid-v0.1.0-linux-amd64"
-    amd64.sha256 = "a02ddd2dda94ab7c3b119541decfd7dee02a064674f9db8277239d0ad9e75013"
+    amd64.url = "https://github.com/github-tijlxyz/khatru-pyramid/releases/download/v0.2.0/khatru-pyramid-v0.2.0-linux-amd64"
+    amd64.sha256 = "82cbf4793767de5b1adc4b8b297c505eb3d5438539595ce45f4fd3e19149529f"
 
     autoupdate.asset.amd64 = "^khatru-pyramid-v.*-linux-amd64$"
     autoupdate.strategy = "latest_github_release"


### PR DESCRIPTION
* Upgrade sources
- `main` v0.2.0: https://github.com/github-tijlxyz/khatru-pyramid/releases/tag/v0.2.0

* Auto-update READMEs